### PR TITLE
Enable TLS for Mozaik

### DIFF
--- a/mozaik/yaml/configmap_homeoffice_redhat.yaml
+++ b/mozaik/yaml/configmap_homeoffice_redhat.yaml
@@ -16,8 +16,9 @@ objects:
       require('dotenv').load();
   
       var config = {
-          env:  'prod',
-  
+          env: 'prod',
+          // Enable when exposing Mozaik via TLS
+          // useWssConnection: true,
           host: '0.0.0.0',
           port: process.env.PORT || 8080,
   

--- a/mozaik/yaml/configmap_template.yaml
+++ b/mozaik/yaml/configmap_template.yaml
@@ -16,8 +16,9 @@ objects:
       require('dotenv').load();
   
       var config = {
-          env:  'prod',
-  
+          env: 'prod',
+          // Enable when exposing Mozaik via TLS
+          // useWssConnection: true,
           host: '0.0.0.0',
           port: process.env.PORT || 8080,
   

--- a/podium-operator/roles/mozaik/tasks/main.yml
+++ b/podium-operator/roles/mozaik/tasks/main.yml
@@ -107,7 +107,8 @@
 
           var config = {
               env:  'prod',
-
+              // Required, otherwise Chrome et al. complain about mixed content warnings when Mozaik is exposed via secured route.
+              useWssConnection: true,
               host: '0.0.0.0',
               port: process.env.PORT || 8080,
 
@@ -205,7 +206,8 @@
         redhat-conf: |
           // Load environment variables from .env file if available
           require('dotenv').load();
-
+          // Required, otherwise Chrome et al. complain about mixed content warnings when Mozaik is exposed via secured route.
+          useWssConnection: true,
           var config = {
               env:  'prod',
 
@@ -403,4 +405,7 @@
           weight: 100
         port:
           targetPort: 8080
+        tls:
+          insecureEdgeTerminationPolicy: Redirect
+          termination: edge
         wildcardPolicy: None


### PR DESCRIPTION
I am not sure if this is useful or not, but I managed to make Mozaik work with a TLS route with the `useWssConnection` parameter. 